### PR TITLE
feat: support existing secret

### DIFF
--- a/charts/bitwarden-external-secrets/Chart.yaml
+++ b/charts/bitwarden-external-secrets/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: bitwarden-external-secrets
 description: Bitwarden secrets without secrets managers
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"

--- a/charts/bitwarden-external-secrets/templates/deployment.yaml
+++ b/charts/bitwarden-external-secrets/templates/deployment.yaml
@@ -26,22 +26,22 @@ spec:
             - name: BW_HOST
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
+                  name: {{ .Values.secrets.existingSecret | default "bitwarden-cli" }}
                   key: BW_HOST
             - name: BW_CLIENTID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
+                  name: {{ .Values.secrets.existingSecret | default "bitwarden-cli" }}
                   key: BW_CLIENTID
             - name: BW_CLIENTSECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
+                  name: {{ .Values.secrets.existingSecret | default "bitwarden-cli" }}
                   key: BW_CLIENTSECRET
             - name: BW_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
+                  name: {{ .Values.secrets.existingSecret | default "bitwarden-cli" }}
                   key: BW_PASSWORD
           ports:
             - name: http

--- a/charts/bitwarden-external-secrets/templates/deployment.yaml
+++ b/charts/bitwarden-external-secrets/templates/deployment.yaml
@@ -26,22 +26,22 @@ spec:
             - name: BW_HOST
               valueFrom:
                 secretKeyRef:
-                  name: bitwarden-cli
+                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
                   key: BW_HOST
             - name: BW_CLIENTID
               valueFrom:
                 secretKeyRef:
-                  name: bitwarden-cli
+                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
                   key: BW_CLIENTID
             - name: BW_CLIENTSECRET
               valueFrom:
                 secretKeyRef:
-                  name: bitwarden-cli
+                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
                   key: BW_CLIENTSECRET
             - name: BW_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: bitwarden-cli
+                  name: {{ .Values.existingSecret | default "bitwarden-cli" }}
                   key: BW_PASSWORD
           ports:
             - name: http

--- a/charts/bitwarden-external-secrets/templates/secret.yaml
+++ b/charts/bitwarden-external-secrets/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 data:
   BW_HOST: {{ .Values.secrets.bw_host | b64enc }}
@@ -11,3 +12,4 @@ metadata:
     app.kubernetes.io/instance: bitwarden-external-secrets
     app.kubernetes.io/part-of: external-secrets
 type: Opaque
+{{- end}}

--- a/charts/bitwarden-external-secrets/templates/secret.yaml
+++ b/charts/bitwarden-external-secrets/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.existingSecret }}
+{{- if not .Values.secrets.existingSecret }}
 apiVersion: v1
 data:
   BW_HOST: {{ .Values.secrets.bw_host | b64enc }}

--- a/charts/bitwarden-external-secrets/values.yaml
+++ b/charts/bitwarden-external-secrets/values.yaml
@@ -10,6 +10,7 @@ operator:
     tag: latest
 
 secrets:
+  existingSecret: ""
   bw_clientid: ""
   bw_clientsecret: ""
   bw_password: ""

--- a/index.yaml
+++ b/index.yaml
@@ -3,12 +3,12 @@ entries:
   bitwarden-external-secrets:
   - apiVersion: v2
     appVersion: 0.3.0
-    created: "2025-08-31T20:52:55.958604107+09:00"
+    created: "2025-08-31T21:31:13.93124082+09:00"
     description: Bitwarden secrets without secrets managers
-    digest: ab0827b4560a278fe4c41c03264051ab7d9be3711a546c8164599509b9600a49
+    digest: 1a8fd96a891479f0a2921465a0e7fab28b16cb01428ab01a9a06868f9f3522ca
     name: bitwarden-external-secrets
     type: application
     urls:
     - https://github.com/tinyrack94/bitwarden-external-secrets/releases/download/bitwarden-external-secrets-0.3.0/bitwarden-external-secrets-0.3.0.tgz
     version: 0.3.0
-generated: "2025-08-31T20:52:55.958257433+09:00"
+generated: "2025-08-31T21:31:13.930864398+09:00"

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+entries:
+  bitwarden-external-secrets:
+  - apiVersion: v2
+    appVersion: 0.3.0
+    created: "2025-08-31T20:52:55.958604107+09:00"
+    description: Bitwarden secrets without secrets managers
+    digest: ab0827b4560a278fe4c41c03264051ab7d9be3711a546c8164599509b9600a49
+    name: bitwarden-external-secrets
+    type: application
+    urls:
+    - https://github.com/tinyrack94/bitwarden-external-secrets/releases/download/bitwarden-external-secrets-0.3.0/bitwarden-external-secrets-0.3.0.tgz
+    version: 0.3.0
+generated: "2025-08-31T20:52:55.958257433+09:00"

--- a/index.yaml
+++ b/index.yaml
@@ -11,4 +11,14 @@ entries:
     urls:
     - https://github.com/tinyrack94/bitwarden-external-secrets/releases/download/bitwarden-external-secrets-0.3.0/bitwarden-external-secrets-0.3.0.tgz
     version: 0.3.0
+  - apiVersion: v2
+    appVersion: 0.3.1
+    created: "2025-08-31T21:34:42.185210752+09:00"
+    description: Bitwarden secrets without secrets managers
+    digest: 5551f0249472cd4b90680adfb306bff83d9940deb9f113c1d1c034407679ffb1
+    name: bitwarden-external-secrets
+    type: application
+    urls:
+    - bitwarden-external-secrets-0.3.1.tgz
+    version: 0.3.1
 generated: "2025-08-31T21:31:13.930864398+09:00"


### PR DESCRIPTION
I added an existingSecret option to the Helm Chart, allowing users to use this chart with a pre-created secret.